### PR TITLE
Kevin/tasks

### DIFF
--- a/db/tasks.py
+++ b/db/tasks.py
@@ -50,7 +50,7 @@ def get_task(task_id: str):
         raise ValueError(f'Get failure: {task_id} not in database.')
 
 
-def get_tasks(filter):
+def get_tasks(filter=None):
     dbc.connect_db()
     return dbc.fetch_all_as_dict(dbc.DB, TASKS_COLLECT, filter)
 

--- a/db/tasks.py
+++ b/db/tasks.py
@@ -38,6 +38,18 @@ BIG_NUM = 100_000_000_000_000_000_000
 MOCK_ID = MOCK_ID = '0' * ID_LEN
 
 
+def id_exists(id: str) -> bool:
+    dbc.connect_db()
+    return dbc.fetch_one(TASKS_COLLECT, {ID: ObjectId(id)})
+
+
+def get_task(task_id: str):
+    if id_exists(task_id):
+        return dbc.fetch_one(TASKS_COLLECT, {ID: ObjectId(task_id)})
+    else:
+        raise ValueError(f'Get failure: {task_id} not in database.')
+
+
 def get_tasks(filter):
     dbc.connect_db()
     return dbc.fetch_all_as_dict(dbc.DB, TASKS_COLLECT, filter)
@@ -64,11 +76,6 @@ def get_new_test_task():
     return test_task
 
 
-def id_exists(id: str) -> bool:
-    dbc.connect_db()
-    return dbc.fetch_one(TASKS_COLLECT, {ID: ObjectId(id)})
-
-
 def add_task(user_id: str, goal: str, content: str, is_completed: bool):
     # if not user_id:
     #     raise ValueError('user_id may not be blank')
@@ -77,8 +84,8 @@ def add_task(user_id: str, goal: str, content: str, is_completed: bool):
     # if not content:
     #     raise ValueError('content may not be blank')
     task = {}
-    task[USER_ID] = user_id
-    task[GOAL_ID] = goal
+    task[USER_ID] = ObjectId(user_id)
+    task[GOAL_ID] = ObjectId(goal)
     task[CONTENT] = content
     task[IS_COMPLETED] = is_completed
     dbc.connect_db()
@@ -91,13 +98,6 @@ def del_task(task_id: str):
         return dbc.del_one(TASKS_COLLECT, {ID: ObjectId(task_id)})
     else:
         raise ValueError(f'Delete failure: {task_id} not in database.')
-
-
-def get_task(task_id: str):
-    if id_exists(task_id):
-        return dbc.fetch_one(TASKS_COLLECT, {ID: ObjectId(task_id)})
-    else:
-        raise ValueError(f'Get failure: {task_id} not in database.')
 
 
 def get_user_tasks(user_id: str):

--- a/db/tasks.py
+++ b/db/tasks.py
@@ -30,7 +30,7 @@ TITLE = 'title'
 CONTENT = 'content'
 STATUS = 'status'
 LIKES = 'likes'
-GOAL = 'Goal'
+GOAL_ID = 'goal_id'
 IS_COMPLETED = 'is_completed'
 
 ID_LEN = 24
@@ -38,9 +38,9 @@ BIG_NUM = 100_000_000_000_000_000_000
 MOCK_ID = MOCK_ID = '0' * ID_LEN
 
 
-def get_tasks():
+def get_tasks(filter):
     dbc.connect_db()
-    return dbc.fetch_all_as_dict(dbc.DB, TASKS_COLLECT, None)
+    return dbc.fetch_all_as_dict(dbc.DB, TASKS_COLLECT, filter)
 
 
 def get_test_tasks():
@@ -58,7 +58,7 @@ def get_new_test_task():
     _id = str(_id)
     _id = _id.rjust(ID_LEN, '0')
     test_task[USER_ID] = '6575033f3b89d2b4f309d7af'
-    test_task[GOAL] = '65d2dd8abe686c2ec340e298'
+    test_task[GOAL_ID] = '65d2dd8abe686c2ec340e298'
     test_task[CONTENT] = 'attend CS101 Office Hours'
     test_task[IS_COMPLETED] = False
     return test_task
@@ -78,7 +78,7 @@ def add_task(user_id: str, goal: str, content: str, is_completed: bool):
     #     raise ValueError('content may not be blank')
     task = {}
     task[USER_ID] = user_id
-    task[GOAL] = goal
+    task[GOAL_ID] = goal
     task[CONTENT] = content
     task[IS_COMPLETED] = is_completed
     dbc.connect_db()

--- a/db/tasks.py
+++ b/db/tasks.py
@@ -84,8 +84,8 @@ def add_task(user_id: str, goal: str, content: str, is_completed: bool):
     # if not content:
     #     raise ValueError('content may not be blank')
     task = {}
-    task[USER_ID] = ObjectId(user_id)
-    task[GOAL_ID] = ObjectId(goal)
+    task[USER_ID] = user_id
+    task[GOAL_ID] = goal
     task[CONTENT] = content
     task[IS_COMPLETED] = is_completed
     dbc.connect_db()

--- a/db/tests/test_tasks.py
+++ b/db/tests/test_tasks.py
@@ -9,9 +9,9 @@ def temp_task():
   task = {}
   task[tsks.USER_ID] = "6575033f3b89d2b4f309d7af"
   task[tsks.CONTENT] = "test content"
-  task[tsks.GOAL] = "65d2dd8abe686c2ec340e298"
+  task[tsks.GOAL_ID] = "65d2dd8abe686c2ec340e298"
   task[tsks.IS_COMPLETED] = False
-  ret = tsks.add_task(task[tsks.USER_ID], task[tsks.GOAL], task[tsks.CONTENT], task[tsks.IS_COMPLETED])
+  ret = tsks.add_task(task[tsks.USER_ID], task[tsks.GOAL_ID], task[tsks.CONTENT], task[tsks.IS_COMPLETED])
   task[tsks.ID] = ret
   return task  
 
@@ -27,7 +27,7 @@ def test_get_all_tasks():
  
 def test_add_task():
   test_task = tsks.get_new_test_task()
-  ret = tsks.add_task(test_task[tsks.USER_ID], test_task[tsks.GOAL], test_task[tsks.CONTENT], test_task[tsks.IS_COMPLETED])
+  ret = tsks.add_task(test_task[tsks.USER_ID], test_task[tsks.GOAL_ID], test_task[tsks.CONTENT], test_task[tsks.IS_COMPLETED])
   assert isinstance(ret, str) # return: str(_id)
   tsks.del_task(ret)
 
@@ -42,14 +42,32 @@ def test_del_task_not_exist():
     tsks.del_task(id)
 
 def test_get_task(temp_task):
+  tsks.add_task()
   task = temp_task
   ret = tsks.get_task(ObjectId(task[tsks.ID]))
   assert isinstance(ret, dict)
   assert ret[tsks.USER_ID] == task[tsks.USER_ID]
-  assert ret[tsks.GOAL] == task[tsks.GOAL]
+  assert ret[tsks.GOAL_ID] == task[tsks.GOAL_ID]
   assert ret[tsks.CONTENT] == task[tsks.CONTENT]
   assert ret[tsks.IS_COMPLETED] == task[tsks.IS_COMPLETED]
   tsks.del_task(ObjectId(task[tsks.ID]))
+
+
+def test_get_task(temp_task):
+  # create task
+  task = temp_task 
+  task_id = task[tsks.ID] # objectID type
+
+  # get task 
+  ret = tsks.get_tasks({tsks.ID: task_id})
+  assert ret is not None
+
+  # delete task 
+  tsks.del_task(task[tsks.ID])
+
+
+
+
 
 def test_get_task_not_exist():
   id = dbc.gen_object_id()
@@ -62,7 +80,7 @@ def test_get_user_tasks(temp_task):
   print(ret[task[tsks.ID]])
   assert isinstance(ret, dict)
   assert ret[task[tsks.ID]][tsks.USER_ID] == task[tsks.USER_ID]
-  assert ret[task[tsks.ID]][tsks.GOAL] == task[tsks.GOAL]
+  assert ret[task[tsks.ID]][tsks.GOAL_ID] == task[tsks.GOAL_ID]
   assert ret[task[tsks.ID]][tsks.CONTENT] == task[tsks.CONTENT]
   assert ret[task[tsks.ID]][tsks.IS_COMPLETED] == task[tsks.IS_COMPLETED]
   tsks.del_task(ObjectId(task[tsks.ID]))

--- a/server/endpoints.py
+++ b/server/endpoints.py
@@ -262,9 +262,14 @@ class ViewTasks(Resource):
         gets all the tasks
         """
         user_id = request.json[tasks.USER_ID]
-        return {
-            TASKS: tasks.get_tasks({tasks.USER_ID: user_id})
-        }
+        if not user_id:
+            return {
+                TASKS: tasks.get_tasks()
+            }
+        else:
+            return {
+                TASKS: tasks.get_tasks({tasks.USER_ID: user_id})
+            }
 
 
 @api.route(f'{PROFILEVALIDATION_EP}', methods=['GET'])

--- a/server/endpoints.py
+++ b/server/endpoints.py
@@ -8,6 +8,7 @@ from flask_restx import Resource, Api, fields
 from db import profiles as pf
 from db import tasks as tasks
 import werkzeug.exceptions as wz
+# from bson.objectid import ObjectId
 # import db.db as db
 
 app = Flask(__name__)
@@ -215,17 +216,24 @@ class RemoveProfile(Resource):
             raise wz.NotAcceptable(f'{str(e)}')
 
 
-@api.route(f'{VIEWTASKS_EP}', methods=['GET'])
+view_task_user_id_field = api.model('ViewTasks', {
+    tasks.USER_ID: fields.String
+})
+
+
+@api.expect(view_task_user_id_field)
+@api.route(f'{VIEWTASKS_EP}', methods=['POST'])
 class ViewTasks(Resource):
     """
     This class will show all tasks
     """
-    def get(self):
+    def post(self):
         """
         gets all the tasks
         """
+        user_id = request.json[tasks.USER_ID]
         return {
-            TASKS: tasks.get_tasks()
+            TASKS: tasks.get_tasks({tasks.USER_ID: user_id})
         }
 
 
@@ -245,7 +253,7 @@ class ProfileValidation(Resource):
 
 new_task_field = api.model('NewTask', {
     tasks.USER_ID: fields.String,
-    tasks.GOAL: fields.String,
+    tasks.GOAL_ID: fields.String,
     tasks.IS_COMPLETED: fields.Boolean,
     tasks.CONTENT: fields.String,
 })
@@ -264,7 +272,7 @@ class PostTask(Resource):
         posts a new task data to create a new task.
         """
         user_id = request.json[tasks.USER_ID]
-        goal = request.json[tasks.GOAL]
+        goal = request.json[tasks.GOAL_ID]
         is_completed = request.json[tasks.IS_COMPLETED]
         content = request.json[tasks.CONTENT]
         try:

--- a/server/endpoints.py
+++ b/server/endpoints.py
@@ -38,6 +38,7 @@ PROFILEVALIDATION_EP = '/profilevalidation'
 REMOVEPROFILE_EP = '/removeProfile'
 VIEWPROFILE_EP = '/viewProfile'
 VIEWUSERPUBLIC_EP = '/viewUserPublic'
+VIEWUSERTASKS_EP = '/viewUserTasks'
 
 
 # Responses
@@ -246,30 +247,39 @@ class RemoveProfile(Resource):
             raise wz.NotAcceptable(f'{str(e)}')
 
 
-view_task_user_id_field = api.model('ViewTasks', {
-    tasks.USER_ID: fields.String
-})
+# view_task_user_id_field = api.model('ViewTasks', {
+#     tasks.USER_ID: fields.String
+# })
 
 
-@api.expect(view_task_user_id_field)
-@api.route(f'{VIEWTASKS_EP}', methods=['POST'])
+# @api.expect(view_task_user_id_field)
+# @api.route(f'{VIEWUSERTASKS_EP}', methods=['POST'])
+# class ViewUserTasks(Resource):
+#     """
+#     This class will show all tasks
+#     """
+#     def post(self):
+#         """
+#         gets all the tasks
+#         """
+#         user_id = request.json[tasks.USER_ID]
+#         return {
+#             TASKS: tasks.get_tasks({tasks.USER_ID: user_id})
+#         }
+
+
+@api.route(f'{VIEWTASKS_EP}', methods=['GET'])
 class ViewTasks(Resource):
     """
     This class will show all tasks
     """
-    def post(self):
+    def get(self):
         """
         gets all the tasks
         """
-        user_id = request.json[tasks.USER_ID]
-        if not user_id:
-            return {
-                TASKS: tasks.get_tasks()
-            }
-        else:
-            return {
-                TASKS: tasks.get_tasks({tasks.USER_ID: user_id})
-            }
+        return {
+            TASKS: tasks.get_tasks()
+        }
 
 
 @api.route(f'{PROFILEVALIDATION_EP}', methods=['GET'])

--- a/server/tests/test_endpoints.py
+++ b/server/tests/test_endpoints.py
@@ -122,8 +122,8 @@ def setup_tasks():
     return task
 
 # check if view tasks works with filter based on user id 
-def test_viewTasks(setup_tasks):
-    resp = TEST_CLIENT.post(ep.VIEWTASKS_EP, json=setup_tasks)
+def test_viewTasks():
+    resp = TEST_CLIENT.get(ep.VIEWTASKS_EP)
     resp_json = resp.get_json()
     assert isinstance(resp_json, dict)
     assert ep.TASKS in resp_json

--- a/server/tests/test_endpoints.py
+++ b/server/tests/test_endpoints.py
@@ -10,7 +10,7 @@ from http.client import (
 import sys
 sys.path.append("..")
 from server import endpoints as ep
-
+from bson.objectid import ObjectId
 from unittest.mock import patch
 
 import db.tasks as tsks
@@ -100,22 +100,29 @@ def test_get_users(mock_get_users):
     assert isinstance(users, dict)
     assert len(users) > 0
 
-# @pytest.mark.skip(reason= "endpoint does not exist yet") 
+@pytest.mark.skip(reason="this ep does not test server ep")
 @patch('db.tasks.get_tasks')
 def test_get_tasks(mock_get_tasks):
     mock_get_tasks.return_value = SAMPLE_TASKS
     tasks = tsks.get_tasks()
     assert isinstance(tasks, dict)
-    assert len(tasks) > 0
+    assert len(tasks) > 0   
 
-@pytest.fixture()
+
+@pytest.fixture(scope="function")
 def setup_tasks():
-    tsks.create_task(SAMPLE_TASK[ep.TASK_NAME], SAMPLE_TASK[ep.TASK_DESCRIPTION], SAMPLE_TASK[ep.LIKE])
-    tsks.add_tasks(SAMPLE_TASKS[ep.TASKS])
+    task = { 
+        tsks.USER_ID: "6575033f3b89d2b4f309d7af",
+        tsks.GOAL_ID: "65d2dd8abe686c2ec340e298", 
+        tsks.CONTENT: "test content",
+        tsks.IS_COMPLETED: False
+    }
+    ret = tsks.add_task(task[tsks.USER_ID], task[tsks.GOAL_ID], task[tsks.CONTENT], task[tsks.IS_COMPLETED])
+    task[tsks.ID] = str(ret)
+    return task
 
-# @pytest.mark.skip(reason="request causes internal server error, please fix this- kevin ng ") 
-def test_viewTasks():
-    resp = TEST_CLIENT.get(ep.VIEWTASKS_EP)
+def test_viewTasks(setup_tasks):
+    resp = TEST_CLIENT.post(ep.VIEWTASKS_EP, json=setup_tasks)
     resp_json = resp.get_json()
     assert isinstance(resp_json, dict)
     assert ep.TASKS in resp_json
@@ -222,7 +229,7 @@ def test_postTask(mock_add):
 
 def test_viewUserTask():
     new_task = tsks.get_new_test_task()
-    test_task_id = str(tsks.add_task(new_task[tsks.USER_ID], new_task[tsks.GOAL], new_task[tsks.CONTENT], new_task[tsks.IS_COMPLETED]))
+    test_task_id = str(tsks.add_task(new_task[tsks.USER_ID], new_task[tsks.GOAL_ID], new_task[tsks.CONTENT], new_task[tsks.IS_COMPLETED]))
     test_user_id = str(new_task[tsks.USER_ID])
     resp = TEST_CLIENT.post(ep.VIEWUSERTASKS_EP, json={tsks.USER_ID: test_user_id})
     resp_json = resp.get_json()
@@ -237,7 +244,7 @@ def test_viewUserTask():
 
 def test_likeTask():
     new_task = tsks.get_new_test_task()
-    test_task_id = str(tsks.add_task(new_task[tsks.USER_ID], new_task[tsks.GOAL], new_task[tsks.CONTENT], new_task[tsks.IS_COMPLETED]))
+    test_task_id = str(tsks.add_task(new_task[tsks.USER_ID], new_task[tsks.GOAL_ID], new_task[tsks.CONTENT], new_task[tsks.IS_COMPLETED]))
     test_user_id = str(dbc.gen_object_id())
     resp = TEST_CLIENT.post(ep.LIKETASK_EP, json={tsks.ID: test_task_id, tsks.USER_ID: test_user_id})
     assert resp.status_code == OK
@@ -245,7 +252,7 @@ def test_likeTask():
 
 def test_unlikeTask():
     new_task = tsks.get_new_test_task()
-    test_task_id = str(tsks.add_task(new_task[tsks.USER_ID], new_task[tsks.GOAL], new_task[tsks.CONTENT], new_task[tsks.IS_COMPLETED]))
+    test_task_id = str(tsks.add_task(new_task[tsks.USER_ID], new_task[tsks.GOAL_ID], new_task[tsks.CONTENT], new_task[tsks.IS_COMPLETED]))
     test_user_id = str(dbc.gen_object_id())
     tsks.like_task(test_task_id, test_user_id)
     resp = TEST_CLIENT.post(ep.UNLIKETASK_EP, json={tsks.ID: test_task_id, tsks.USER_ID: test_user_id})

--- a/server/tests/test_endpoints.py
+++ b/server/tests/test_endpoints.py
@@ -108,7 +108,7 @@ def test_get_tasks(mock_get_tasks):
     assert isinstance(tasks, dict)
     assert len(tasks) > 0   
 
-
+# add task to database and return the task details passing its own id as a string
 @pytest.fixture(scope="function")
 def setup_tasks():
     task = { 
@@ -121,8 +121,7 @@ def setup_tasks():
     task[tsks.ID] = str(ret)
     return task
 
-# add task to database and then check if view tasks works with filter based on user id 
-# asser a value return task value(s) was given 
+# check if view tasks works with filter based on user id 
 def test_viewTasks(setup_tasks):
     resp = TEST_CLIENT.post(ep.VIEWTASKS_EP, json=setup_tasks)
     resp_json = resp.get_json()

--- a/server/tests/test_endpoints.py
+++ b/server/tests/test_endpoints.py
@@ -121,6 +121,8 @@ def setup_tasks():
     task[tsks.ID] = str(ret)
     return task
 
+# add task to database and then check if view tasks works with filter based on user id 
+# asser a value return task value(s) was given 
 def test_viewTasks(setup_tasks):
     resp = TEST_CLIENT.post(ep.VIEWTASKS_EP, json=setup_tasks)
     resp_json = resp.get_json()
@@ -131,6 +133,7 @@ def test_viewTasks(setup_tasks):
     for task_id in tasks:
         assert isinstance(task_id, str)
         assert isinstance(tasks[task_id], dict)
+
 
 @patch('db.tasks.add_task', return_value=tsks.MOCK_ID, autospec=True)
 def test_postTask(mock_add):


### PR DESCRIPTION
- updated viewtask endpoints to follow new model
- finished user-id based filtering (and general use) for view task endpoints 
- did some endpoint cleaning for conciseness and debugging inconsistencies
- view_task endpoint is complete (db & server side) 
- comments added for explanation 
- rebase commit (please ignore) 

core files to look at:
- db/tasks.py 
- db/tests/test_tasks.py 
- server/endpoints.py (tasks endpoints)
- server/test_endpoints.py (tasks endpoints) 