### PR TITLE
post post ep complete

### DIFF
--- a/db/posts.py
+++ b/db/posts.py
@@ -1,4 +1,7 @@
+import db.db_connect as dbc
+
 MOCK_ID = 0
+POSTS_COLLECT = "posts"
 USER_ID = "user_id"
 IS_COMPLETED = "is_completed"
 CONTENT = "content"
@@ -27,4 +30,16 @@ def add_post(user_id,
              goal_ids,
              like_ids,
              comment_ids):
-    pass
+    dbc.connect_db()
+    _id = dbc.insert_one(
+                        POSTS_COLLECT,
+                        {
+                            USER_ID: user_id,
+                            IS_COMPLETED: is_completed,
+                            CONTENT: content,
+                            TASK_IDS: task_ids,
+                            GOAL_IDS: goal_ids,
+                            LIKE_IDS: like_ids,
+                            COMMENT_IDS: comment_ids
+                        })
+    return _id

--- a/db/posts.py
+++ b/db/posts.py
@@ -13,7 +13,7 @@ COMMENT_IDS = "comment_ids"
 
 def get_test_post():
     return {
-        USER_ID: "1",
+        USER_ID: "65f27756a4817e4be8a2a5e9",
         IS_COMPLETED: False,
         CONTENT: "test task",
         TASK_IDS: [],

--- a/db/tests/test_posts.py
+++ b/db/tests/test_posts.py
@@ -4,18 +4,18 @@ import db.posts as psts
 @pytest.fixture()
 def generate_post_fields():
     return {
-        psts.USER_ID: None, 
+        psts.USER_ID: '65f27756a4817e4be8a2a5e9', 
         psts.IS_COMPLETED: False, 
         psts.CONTENT: "Test Entry", 
         psts.TASK_IDS: [], 
         psts.GOAL_IDS: [], 
         psts.LIKE_IDS: [],
         psts.COMMENT_IDS: [], 
-    }
+    }   
 
 def test_add_post(generate_post_fields):
     """
-    Tests that add_post returned post id 
+    Tests that add_post returned post id
     """
     post_id = psts.add_post(**generate_post_fields)
     assert post_id is not None  

--- a/db/tests/test_posts.py
+++ b/db/tests/test_posts.py
@@ -1,0 +1,22 @@
+import pytest
+import db.posts as psts
+
+@pytest.fixture()
+def generate_post_fields():
+    return {
+        psts.USER_ID: None, 
+        psts.IS_COMPLETED: False, 
+        psts.CONTENT: "Test Entry", 
+        psts.TASK_IDS: [], 
+        psts.GOAL_IDS: [], 
+        psts.LIKE_IDS: [],
+        psts.COMMENT_IDS: [], 
+    }
+
+def test_add_post(generate_post_fields):
+    """
+    Tests that add_post returned post id 
+    """
+    post_id = psts.add_post(**generate_post_fields)
+    assert post_id is not None  
+


### PR DESCRIPTION
User can now create a post by providing fields:
`
{
  USER_ID = "user_id"
  IS_COMPLETED = "is_completed"
  CONTENT = "content"
  TASK_IDS = "task_ids"
  GOAL_IDS = "goal_ids"
}
`

Output from swagger & test:
<img width="719" alt="pytest_swaggertest_result" src="https://github.com/bk00119/BEKK/assets/80858693/42f09153-fe1d-453c-a887-f50fcbb37ae2">

create post ep is not done .... some ideas to think about henceforth on post post ep: 
1. `user_id` autofill based on session after discussing auth ep 
2. `is_Completed` will be default `false`, so it can removed in the future 
3. `task_ids` & `goal_ids` will depend on user to input (maybe dropdown displaying user's tasks & goals aliasing the id) 
4. `goal_ids` maybe should be a singular string (one goal per post?)

